### PR TITLE
Expand linting and test coverage to all modules

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,14 +37,14 @@ jobs:
     
     - name: Run linting
       run: |
-        flake8 app.py --max-line-length=120 --exclude=venv,__pycache__
-    
+        flake8 app.py ai_models.py auth.py cache.py tts_helpers.py youtube_helpers.py --max-line-length=120 --exclude=venv,__pycache__
+
     - name: Run tests with coverage
       env:
         GOOGLE_API_KEY: test_api_key
         TESTING: true
       run: |
-        pytest --cov=app --cov-report=xml --cov-report=term-missing -v
+        pytest --cov=app --cov=ai_models --cov=auth --cov=cache --cov=tts_helpers --cov=youtube_helpers --cov-report=xml --cov-report=term-missing -v
     
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3

--- a/app.py
+++ b/app.py
@@ -448,8 +448,6 @@ def get_client_ip():
     return client_ip
 
 
-
-
 # --- INITIALIZE WORKER SYSTEM ---
 # Initialize worker system now that all functions are defined
 init_worker_system()


### PR DESCRIPTION
## Summary
Extended the CI/CD pipeline to include linting and code coverage checks for all application modules, not just the main `app.py` file. Also cleaned up unnecessary blank lines in the codebase.

## Key Changes
- **Linting**: Updated flake8 to check `ai_models.py`, `auth.py`, `cache.py`, `tts_helpers.py`, and `youtube_helpers.py` in addition to `app.py`
- **Test Coverage**: Expanded pytest coverage reporting to include all modules (`ai_models`, `auth`, `cache`, `tts_helpers`, `youtube_helpers`) alongside the main `app` module
- **Code Cleanup**: Removed 2 unnecessary blank lines in `app.py` before the worker system initialization comment

## Details
These changes ensure consistent code quality standards across the entire codebase by applying the same linting rules and coverage requirements to all modules. This improves maintainability and helps catch potential issues earlier in the development process.

https://claude.ai/code/session_01L7a9xJ6sXgEsxJFNhzuR8n