### PR TITLE
Fix: make summary cache writes atomic and thread-safe

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -1,6 +1,12 @@
 import json
 import os
+import tempfile
+import threading
 from datetime import datetime, timezone
+
+# Serializes cache writes within a process so concurrent request threads and
+# worker threads cannot truncate or interleave each other's writes.
+_cache_write_lock = threading.Lock()
 
 
 def load_summary_cache(cache_file):
@@ -28,9 +34,28 @@ def save_summary_cache(cache, cache_file):
     Args:
         cache: dict mapping video_id to cache entry dicts.
         cache_file: Path to the JSON cache file.
+
+    The write is atomic (serialized via a lock, written to a temp file in the
+    same directory, then ``os.replace``d into place) so a crash or a concurrent
+    writer can never leave a truncated/corrupt cache on disk.
     """
-    with open(cache_file, "w") as f:
-        json.dump(cache, f, indent=4)
+    with _cache_write_lock:
+        directory = os.path.dirname(cache_file) or "."
+        os.makedirs(directory, exist_ok=True)
+        # Snapshot under the lock to avoid "dictionary changed size during
+        # iteration" if another thread mutates the cache while we serialize it.
+        payload = json.dumps(dict(cache), indent=4)
+        fd, tmp_path = tempfile.mkstemp(dir=directory, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w") as f:
+                f.write(payload)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, cache_file)
+        except BaseException:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+            raise
 
 
 def build_cache_entry(title, summary, thumbnail_url, video_id, model_key, audio_filename=None):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -78,35 +78,47 @@ class TestCacheFunctions(unittest.TestCase):
 
         self.assertEqual(cache, {})
 
-    @patch("builtins.open", new_callable=mock_open)
-    def test_save_summary_cache(self, mock_file):
-        """Test saving cache data"""
-        save_summary_cache(self.test_cache_data, CACHE_FILE)
+    def test_save_summary_cache(self):
+        """Test saving cache data writes valid JSON that round-trips."""
+        import tempfile
 
-        mock_file.assert_called_once_with(CACHE_FILE, "w")
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            cache_path = os.path.join(tmp_dir, "summary_cache.json")
+            save_summary_cache(self.test_cache_data, cache_path)
 
-        # Get the written content
-        handle = mock_file()
-        written_data = "".join(call.args[0] for call in handle.write.call_args_list)
+            with open(cache_path, "r") as f:
+                parsed_data = json.load(f)
 
-        # Verify the data was written correctly
-        parsed_data = json.loads(written_data)
-        self.assertEqual(parsed_data, self.test_cache_data)
+            self.assertEqual(parsed_data, self.test_cache_data)
+            # Atomic write must not leave temp files behind.
+            self.assertEqual(os.listdir(tmp_dir), ["summary_cache.json"])
 
-    @patch("builtins.open", new_callable=mock_open)
-    def test_save_summary_cache_empty(self, mock_file):
-        """Test saving empty cache"""
-        save_summary_cache({}, CACHE_FILE)
+    def test_save_summary_cache_empty(self):
+        """Test saving empty cache."""
+        import tempfile
 
-        mock_file.assert_called_once_with(CACHE_FILE, "w")
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            cache_path = os.path.join(tmp_dir, "summary_cache.json")
+            save_summary_cache({}, cache_path)
 
-        # Get the written content
-        handle = mock_file()
-        written_data = "".join(call.args[0] for call in handle.write.call_args_list)
+            with open(cache_path, "r") as f:
+                parsed_data = json.load(f)
 
-        # Verify empty dict was written
-        parsed_data = json.loads(written_data)
-        self.assertEqual(parsed_data, {})
+            self.assertEqual(parsed_data, {})
+
+    def test_save_summary_cache_overwrite_is_atomic(self):
+        """A second save fully replaces prior contents without corruption."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            cache_path = os.path.join(tmp_dir, "summary_cache.json")
+            save_summary_cache(self.test_cache_data, cache_path)
+            save_summary_cache({"video3": {"title": "Only One"}}, cache_path)
+
+            with open(cache_path, "r") as f:
+                parsed_data = json.load(f)
+
+            self.assertEqual(parsed_data, {"video3": {"title": "Only One"}})
 
     def test_build_cache_entry_structure(self):
         """Test that build_cache_entry returns a dict with all expected keys"""


### PR DESCRIPTION
## Problem
`save_summary_cache()` truncated the cache file with `open(cache_file, "w")` and then `json.dump`'d into it, with no locking. This had three failure modes:

1. **Corruption on crash** — a crash or exception mid-`dump` leaves a truncated/invalid JSON file, which then loads as `{}` (silent total cache loss).
2. **Concurrent writers** — Flask request threads (`_summarize_and_cache`, `delete_summary`) and worker threads all call this with no serialization, so writes interleave and clobber each other (last-writer-wins).
3. **`dictionary changed size during iteration`** — `json.dump` iterating the dict while another thread inserts raises a `RuntimeError` that 500s the request *after* the summary was already generated.

## Fix
- Serialize writes with a module-level `threading.Lock`.
- Snapshot the dict (`dict(cache)`) before serializing so concurrent mutation can't break the dump.
- Write to a temp file in the same directory, `fsync`, then `os.replace()` into place — an atomic rename, so the on-disk cache is always a complete, valid file.

## Tests
- Rewrote the two save tests to verify real round-trip behavior (the old tests asserted the now-obsolete `open(..., "w")` call), and added a test that a second save atomically replaces prior contents and leaves no temp files behind.
- `pytest tests/test_cache.py` → 12 passed.

> Note: this addresses single-process correctness (`python app.py`). Cross-process safety under multi-worker gunicorn is a separate, larger issue tracked elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)