### PR TITLE
Fix: flake8 failure blocking CI

### DIFF
--- a/app.py
+++ b/app.py
@@ -448,8 +448,6 @@ def get_client_ip():
     return client_ip
 
 
-
-
 # --- INITIALIZE WORKER SYSTEM ---
 # Initialize worker system now that all functions are defined
 init_worker_system()


### PR DESCRIPTION
## Problem
CI has been failing on every push to `main` (e.g. the latest "Break up summarize_links route" run failed in 31s). The `Run linting` step runs `flake8 app.py`, and `app.py` had **four** consecutive blank lines before the `INITIALIZE WORKER SYSTEM` section, which trips `E303 too many blank lines (4)` and `E305`. These codes aren't in the project's `.flake8` ignore list, so flake8 exits non-zero and fails the job.

## Fix
Collapse the four blank lines to the standard two. `flake8 app.py --max-line-length=120` now passes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)