### PR TITLE
Fix: SSE events broadcast to every client (session_id always None)

### DIFF
--- a/app.py
+++ b/app.py
@@ -458,6 +458,20 @@ init_worker_system()
 # --- API ENDPOINTS ---
 
 
+@app.before_request
+def ensure_session_id():
+    """Assign a stable per-session id used to target SSE events.
+
+    Set on every request (the short-circuit means only the first one writes)
+    so the cookie is in place before the browser opens the /events stream.
+    Without this, SSE connections register with session_id=None and progress
+    events get broadcast to every connected client instead of just the user
+    who started the job.
+    """
+    if not session.get("session_id"):
+        session["session_id"] = str(uuid.uuid4())
+
+
 @app.route("/")
 @require_auth
 def home():
@@ -599,7 +613,7 @@ def sse_events():
     connection_id = str(uuid.uuid4())
 
     # Get client information for security and tracking
-    session_id = session.get("session_id") or session.sid if hasattr(session, "sid") else None
+    session_id = session.get("session_id") or (session.sid if hasattr(session, "sid") else None)
     client_ip = get_client_ip()
 
     # Get subscription preferences from query parameters
@@ -1164,7 +1178,7 @@ def summarize_links():
             available_models = list(AVAILABLE_MODELS.keys())
             return jsonify({"error": f"Unsupported model: {model_key}. Available models: {available_models}"}), 400
 
-        session_id = session.get("session_id") or session.sid if hasattr(session, "sid") else None
+        session_id = session.get("session_id") or (session.sid if hasattr(session, "sid") else None)
 
         # Send initial progress notification
         has_playlists = any(get_playlist_id(url) for url in urls)


### PR DESCRIPTION
## Problem
Real-time progress/completion events leaked across users. The session id was computed as:

```python
session_id = session.get("session_id") or session.sid if hasattr(session, "sid") else None
```

which Python parses as `(session.get("session_id") or session.sid) if hasattr(session, "sid") else None`. Plain Flask's session object has no `.sid`, so `hasattr(...)` is `False` and **`session_id` is always `None`**, even when `session["session_id"]` is set.

Consequence: every SSE connection registered with `session_id=None`, and `_notify_progress` / `_notify_complete` broadcast with `session_filter=None`, which `broadcast_to_connections` treats as "no filter" — so every connected client received every other user's `summary_progress` / `summary_complete` events (titles of videos being summarized, etc.).

## Fix
- Add parentheses so the expression is `session.get("session_id") or (session.sid if hasattr(session, "sid") else None)` (both occurrences).
- Add a `before_request` hook that assigns a stable `session_id` early. This matters because the SSE stream (`/events`) is opened at page load, *before* the first summarize — without an id already in the cookie, the connection would register with `None` and corrected filtering would *drop* events instead of leaking them. Assigning it up front makes the connection and the notifications share the same id.

## Tests
- Full suite: 497 passed, 26 skipped (unchanged from baseline).

> Note: CI red on this branch is the pre-existing flake8 blank-line issue inherited from `main` (fixed in #15); it resolves once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)