### PR TITLE
Fix: async submit reports failures as success; rate limiter bypassed

### DIFF
--- a/app.py
+++ b/app.py
@@ -1251,6 +1251,8 @@ def summarize_async():
 
         # Submit jobs to worker queue
         job_ids = []
+        failures = []
+        client_ip = get_client_ip()
         session_id = session.get("session_id", str(uuid.uuid4()))
         session["session_id"] = session_id
 
@@ -1261,25 +1263,32 @@ def summarize_async():
             if video_id:
                 # Single video job
                 job = create_video_job(url=url, model_key=model_key, session_id=session_id)
-
-                if worker_manager.submit_job(job):
-                    job_ids.append(job.job_id)
-
             elif playlist_id:
                 # Playlist job - video IDs are fetched by the worker during processing
                 job = create_playlist_job(url=url, video_ids=[], model_key=model_key, session_id=session_id)
+            else:
+                failures.append({"url": url, "error": "Not a valid YouTube video or playlist URL"})
+                continue
 
-                if worker_manager.submit_job(job):
-                    job_ids.append(job.job_id)
+            # submit_job returns (success, message); a failure tuple is truthy,
+            # so it must be unpacked rather than tested directly. Pass client_ip
+            # so the per-IP rate limiter actually applies.
+            success, message = worker_manager.submit_job(job, client_ip)
+            if success:
+                job_ids.append(job.job_id)
+            else:
+                failures.append({"url": url, "error": message})
 
         if not job_ids:
-            return jsonify({"error": "Failed to submit any jobs"}), 500
+            error_detail = failures[0]["error"] if failures else "No valid URLs to submit"
+            return jsonify({"error": f"Failed to submit any jobs: {error_detail}", "failures": failures}), 500
 
         return jsonify(
             {
                 "success": True,
                 "message": f"Submitted {len(job_ids)} jobs for processing",
                 "job_ids": job_ids,
+                "failures": failures,
                 "session_id": session_id,
             }
         )

--- a/tests/test_async_endpoints.py
+++ b/tests/test_async_endpoints.py
@@ -47,6 +47,9 @@ def mock_worker_system():
     with patch("app.WORKER_SYSTEM_AVAILABLE", True):
         # Create mock instances
         mock_worker_manager = Mock()
+        # submit_job returns (success, message); default to success so endpoint
+        # tests that don't care about the result still get a valid tuple.
+        mock_worker_manager.submit_job.return_value = (True, "job submitted")
         mock_job_state_manager = Mock()
         mock_sse_manager = Mock()
 
@@ -98,7 +101,7 @@ class TestAsyncJobSubmission:
             status=JobStatus.PENDING,
         )
 
-        mock_worker_system["worker_manager"].submit_job.return_value = job_id
+        mock_worker_system["worker_manager"].submit_job.return_value = (True, job_id)
         mock_worker_system["job_state_manager"].get_job_status.return_value = mock_job.to_dict()
 
         response = client.post("/summarize_async", json=sample_job_data, content_type="application/json")
@@ -121,7 +124,7 @@ class TestAsyncJobSubmission:
             status=JobStatus.PENDING,
         )
 
-        mock_worker_system["worker_manager"].submit_job.return_value = job_id
+        mock_worker_system["worker_manager"].submit_job.return_value = (True, job_id)
         mock_worker_system["job_state_manager"].get_job_status.return_value = mock_job.to_dict()
 
         response = client.post(
@@ -212,7 +215,7 @@ class TestAsyncJobSubmission:
             "model": "gpt-4o",
         }
 
-        mock_worker_system["worker_manager"].submit_job.return_value = True
+        mock_worker_system["worker_manager"].submit_job.return_value = (True, "job submitted")
 
         response = client.post("/summarize_async", json=custom_data, content_type="application/json")
 
@@ -591,7 +594,7 @@ class TestRateLimiting:
 #
 #         def submit_job(job_data):
 #             job_id = str(uuid.uuid4())
-#             mock_worker_system["worker_manager"].submit_job.return_value = job_id
+#             mock_worker_system["worker_manager"].submit_job.return_value = (True, job_id)
 #             return client.post(
 #                 "/summarize_async", json=job_data, content_type="application/json"
 #             )


### PR DESCRIPTION
## Problem
`WorkerManager.submit_job` returns `tuple[bool, str]` — `(success, message)`. But `/summarize_async` did:

```python
if worker_manager.submit_job(job):
    job_ids.append(job.job_id)
```

A failure tuple such as `(False, "Queue is full")` is **truthy**, so failed submissions were appended/treated as successes. The client received `{"success": true, "job_ids": [...]}` for jobs that were never queued, then polled job IDs that will never exist.

Separately, `submit_job(job)` was called **without `client_ip`**, and the scheduler's rate-limit check is gated on `if client_ip and ...` — so the documented 60 req/min/IP limit was never enforced on this path.

## Fix
- Unpack `success, message = worker_manager.submit_job(job, client_ip)` and only record `job_id` on real success.
- Pass `client_ip` so the per-IP rate limiter actually applies.
- Accumulate per-URL `failures` and return them; when nothing could be queued, surface the first failure reason instead of a generic 500.

## Tests
- Updated `test_async_endpoints.py` mocks to return the real `(success, message)` tuple — they previously returned a bare `job_id`/`True`, which only "worked" because of the truthiness bug this PR fixes. Added a correct default in the fixture.
- `test_async_endpoints.py` → 33 passed; `test_app_integration.py` unaffected (32 passed); full suite → 497 passed, 26 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)