### PR TITLE
Security: reject invalid voice_id in /speak (path traversal)

### DIFF
--- a/app.py
+++ b/app.py
@@ -45,6 +45,7 @@ from voice_config import (
     get_voice_with_fallback,
     get_voices_by_tier,
     should_cleanup_cache,
+    validate_voice_name,
 )
 
 import auth
@@ -1345,8 +1346,13 @@ def speak():
     except Exception as e:
         return jsonify({"error": f"Failed to parse request: {str(e)}"}), 400
 
-    # Get voice selection from request data (default to configured voice)
+    # Get voice selection from request data (default to configured voice).
+    # voice_id becomes the leading component of the cache filename, so reject
+    # anything not in the known-voice allowlist to prevent path traversal
+    # (e.g. "../../etc/x") into the audio cache write/read.
     voice_id = data.get("voice_id", TTS_VOICE)
+    if not validate_voice_name(voice_id):
+        return jsonify({"error": "Invalid voice selection"}), 400
 
     # Check if cache cleanup is needed (do this before generating cache key)
     if should_cleanup_cache(AUDIO_CACHE_DIR):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -215,6 +215,16 @@ class TestYouTubeSummarizer(unittest.TestCase):
         response = self.client.post("/speak", data=json.dumps({}), content_type="application/json")
         self.assertEqual(response.status_code, 400)
 
+    def test_speak_rejects_path_traversal_voice_id(self):
+        """voice_id outside the known-voice allowlist must be rejected (path traversal)."""
+        response = self.client.post(
+            "/speak",
+            data=json.dumps({"text": "Test text", "voice_id": "../../../../tmp/pwn"}),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Invalid voice", response.get_json()["error"])
+
     @patch("os.path.exists")
     @patch("builtins.open", new_callable=mock_open, read_data=b"fake audio content")
     def test_speak_cached_audio(self, mock_file, mock_exists):


### PR DESCRIPTION
## Problem
`/speak` read `voice_id` from the request body and passed it unvalidated to `get_optimized_cache_key(voice_id, text)`, which returns `f"{voice_id}_{text_hash}"`. That becomes the audio cache filename, with `voice_id` as the **leading path component**:

```python
filename = f"{cache_key}.mp3"
filepath = os.path.join(AUDIO_CACHE_DIR, filename)   # voice_id leads the path
...
synthesize_audio(tts_client, voice_id, text_to_speak, filepath)  # open(filepath, "wb")
```

An authenticated user could send `voice_id = "../../../../tmp/pwn"` to make `filepath` escape `AUDIO_CACHE_DIR`, writing attacker-controlled MP3 bytes outside the cache directory. `voice_config.validate_voice_name()` existed for exactly this purpose but was never called.

## Fix
Validate `voice_id` against the known-voice allowlist (`validate_voice_name`) and return `400 Invalid voice selection` on a miss, before it ever reaches the filesystem path.

## Tests
- Added `test_speak_rejects_path_traversal_voice_id`.
- The default `TTS_VOICE` and `DEFAULT_VOICE` both validate `True`, so legitimate requests (which omit `voice_id`) are unaffected. `test_app.py` → 65 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)