### PR TITLE
Security: fix reflected XSS on login page

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -164,12 +164,22 @@
         }
 
         function showError(message) {
-            errorContainer.innerHTML = `<div class="error-message">${message}</div>`;
+            // Use textContent (not innerHTML) so query-param messages can't
+            // inject markup — these come from the URL and are attacker-controllable.
+            errorContainer.innerHTML = '';
+            const div = document.createElement('div');
+            div.className = 'error-message';
+            div.textContent = message;
+            errorContainer.appendChild(div);
             infoContainer.innerHTML = '';
         }
 
         function showInfo(message) {
-            infoContainer.innerHTML = `<div class="info-message">${message}</div>`;
+            infoContainer.innerHTML = '';
+            const div = document.createElement('div');
+            div.className = 'info-message';
+            div.textContent = message;
+            infoContainer.appendChild(div);
             errorContainer.innerHTML = '';
         }
 


### PR DESCRIPTION
## Problem
`login.html` reads the `error` and `message` query parameters, `decodeURIComponent`s them, and injects them into the DOM via `innerHTML`:

```js
errorContainer.innerHTML = `<div class="error-message">${message}</div>`;
```

A crafted link like `/login?error=<img src=x onerror=alert(1)>` therefore executes arbitrary script **before authentication**, in the victim's session/origin.

## Fix
Rewrite `showError`/`showInfo` to create the message element and set its text via `textContent`, so URL-supplied content is rendered as text, never markup. All callers pass plain strings, so behavior/styling is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)