### PR TITLE
Security: default Flask debug mode to off

### DIFF
--- a/app.py
+++ b/app.py
@@ -1612,7 +1612,7 @@ def settings_page():
         "WEBSHARE_PROXY_USERNAME": os.environ.get("WEBSHARE_PROXY_USERNAME", ""),
         "WEBSHARE_PROXY_PASSWORD": os.environ.get("WEBSHARE_PROXY_PASSWORD", ""),
         "DATA_DIR": os.environ.get("DATA_DIR", ""),
-        "FLASK_DEBUG": os.environ.get("FLASK_DEBUG", "true"),
+        "FLASK_DEBUG": os.environ.get("FLASK_DEBUG", "false"),
         "TTS_VOICE": os.environ.get("TTS_VOICE", "en-US-Chirp3-HD-Zephyr"),
     }
 
@@ -1856,8 +1856,10 @@ atexit.register(cleanup_worker_system)
 
 if __name__ == "__main__":
     try:
-        # Enable debug mode only in development (configurable via environment variable)
-        debug_mode = os.environ.get("FLASK_DEBUG", "true").lower() == "true"
+        # Debug mode is OFF by default; opt in with FLASK_DEBUG=true for local dev only.
+        # The Werkzeug debugger allows remote code execution, so it must never
+        # default on for a deployed instance.
+        debug_mode = os.environ.get("FLASK_DEBUG", "false").lower() == "true"
         print(f"🚀 Starting YouTube Summarizer on port 5001 (debug={debug_mode})")
         app.run(debug=debug_mode, port=5001)
     except KeyboardInterrupt:


### PR DESCRIPTION
## Problem
`FLASK_DEBUG` defaulted to `"true"` in both the runtime entrypoint and the settings defaults:

```python
debug_mode = os.environ.get("FLASK_DEBUG", "true").lower() == "true"
app.run(debug=debug_mode, port=5001)
```

So unless an operator explicitly set `FLASK_DEBUG=false`, the app ran with the Werkzeug interactive debugger enabled. That debugger allows **arbitrary code execution** through the traceback console on any unhandled exception — a critical risk for any exposed instance.

## Fix
Default `FLASK_DEBUG` to `"false"` (both the `app.run` entrypoint and the settings-page default). Debug is now strictly opt-in via `FLASK_DEBUG=true` for local development.

## Note
This doesn't remove the ability to toggle debug from the settings page — that's a separate concern (the settings endpoint being over-powered). This change ensures the *default* posture is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)