### PR TITLE
Security: constant-time passcode comparison (and fix special-char codes)

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 import atexit
 import hashlib  # For generating filenames
+import hmac  # For constant-time passcode comparison
 import html  # For HTML escaping user inputs
 import json
 import os
@@ -517,11 +518,10 @@ def login():
         if not passcode:
             return jsonify({"error": "Passcode is required"}), 400
 
-        # Sanitize passcode input to prevent XSS
-        passcode = html.escape(passcode)
-
-        # Simple authentication check
-        if passcode == LOGIN_CODE:
+        # Constant-time comparison to avoid leaking the passcode via timing.
+        # (The passcode is never reflected back, so there's no XSS reason to
+        # html.escape it here — and escaping broke codes containing & < > " '.)
+        if hmac.compare_digest(passcode.encode("utf-8"), (LOGIN_CODE or "").encode("utf-8")):
             # Reset failed attempts on successful login
             reset_failed_attempts(client_ip)
             session["authenticated"] = True

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -59,6 +59,25 @@ class TestYouTubeSummarizer(unittest.TestCase):
         response = self.client.get("/")
         self.assertEqual(response.status_code, 200)
 
+    def test_login_accepts_passcode_with_special_chars(self):
+        """A correct passcode containing HTML special chars must authenticate.
+
+        The old code html.escape'd the passcode before comparing, so codes
+        containing & < > " ' could never match.
+        """
+        if "TESTING" in os.environ:
+            del os.environ["TESTING"]
+        with patch("app.LOGIN_ENABLED", True), patch("app.LOGIN_CODE", "p@ss&w<rd>"), patch(
+            "app.is_ip_locked_out", return_value=(False, 0)
+        ), patch("app.reset_failed_attempts"):
+            response = self.client.post(
+                "/login",
+                data=json.dumps({"passcode": "p@ss&w<rd>"}),
+                content_type="application/json",
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(json.loads(response.data)["success"])
+
     def test_get_cached_summaries_empty(self):
         """Test getting cached summaries when cache is empty"""
         with patch("app.summary_cache", {}):


### PR DESCRIPTION
## Problem
Two issues in the `/login` passcode check:

1. **Not constant-time.** `if passcode == LOGIN_CODE:` short-circuits on the first differing byte, leaking information about the secret via response timing.
2. **Escape-before-compare bug.** `passcode = html.escape(passcode)` ran before the comparison. The passcode is never reflected to a page, so escaping gave no XSS benefit — but it meant any `LOGIN_CODE` containing `&`, `<`, `>`, `"`, or `'` could **never** be entered correctly (e.g. `a&b` became `a&amp;b`).

## Fix
- Compare with `hmac.compare_digest(...)` over UTF-8 bytes (constant-time, and safe for non-ASCII codes).
- Remove the `html.escape` of the passcode.

## Tests
- Added `test_login_accepts_passcode_with_special_chars` (a code containing `&<>` now authenticates).
- `test_app.py` → 65 passed.

> Note: this hardens the comparison itself. The separate issue that the per-IP lockout trusts a spoofable `X-Forwarded-For` is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)