### PR TITLE
Fix: priority queue was LIFO within a priority level

### DIFF
--- a/job_queue.py
+++ b/job_queue.py
@@ -79,14 +79,16 @@ class PriorityJobQueue:
                 return False
 
             # Add to heap queue with priority ordering
-            # Use negative counter for FIFO ordering within same priority
+            # Use an increasing counter as a tiebreaker for FIFO ordering within
+            # the same priority (earlier submissions have a smaller counter and
+            # are popped first).
             self._counter += 1
             priority_value = job.priority.value
             timestamp = time.time()
 
-            # Heap entry: (priority, -counter, timestamp, job_id)
+            # Heap entry: (priority, counter, timestamp, job_id)
             # Lower priority values have higher priority (1 = HIGH, 2 = MEDIUM, 3 = LOW)
-            heap_entry = (priority_value, -self._counter, timestamp, job.job_id)
+            heap_entry = (priority_value, self._counter, timestamp, job.job_id)
             heapq.heappush(self._queue, heap_entry)
 
             # Store job in lookup dict

--- a/tests/test_job_queue.py
+++ b/tests/test_job_queue.py
@@ -92,6 +92,8 @@ class TestPriorityJobQueue:
         assert len(set(retrieved_job_ids)) == 5
         expected_ids = {f"job-{i}" for i in range(5)}
         assert set(retrieved_job_ids) == expected_ids
+        # Same priority must come out in submission order (FIFO), not LIFO.
+        assert retrieved_job_ids == [f"job-{i}" for i in range(5)]
 
     def test_put_duplicate_job_id(self):
         """Test that duplicate job IDs are rejected"""


### PR DESCRIPTION
## Problem
The heap entry used `-self._counter` as the intra-priority tiebreaker:

```python
heap_entry = (priority_value, -self._counter, timestamp, job.job_id)  # comment said "FIFO"
```

`_counter` increases with each submission, so a *later* job gets a *more negative* second element and is popped **first** — that's LIFO, the opposite of the documented FIFO. Under a steady stream of same-priority jobs, the earliest-submitted job sits at the back and can starve.

## Fix
Use `+self._counter` so earlier submissions (smaller counter) pop first. Strengthened `test_put_same_priority_fifo_ordering` to assert the exact submission order instead of just uniqueness.

## Tests
- `test_job_queue.py` → 39 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)