### PR TITLE
Fix: transcript fallback broken on youtube-transcript-api 1.x

### DIFF
--- a/tests/test_transcript_and_summary.py
+++ b/tests/test_transcript_and_summary.py
@@ -292,6 +292,31 @@ class TestTranscriptWithProxy(unittest.TestCase):
         )
         mock_list_transcripts.assert_called_once_with("test_video_id", proxies=expected_proxies)
 
+    @patch("youtube_helpers.YouTubeTranscriptApi.list_transcripts")
+    @patch("youtube_helpers.YouTubeTranscriptApi.get_transcript")
+    def test_get_transcript_fallback_v1_fetchedtranscript(self, mock_get_transcript, mock_list_transcripts):
+        """Fallback handles youtube-transcript-api 1.x FetchedTranscript (snippet objects)."""
+        from youtube_transcript_api import NoTranscriptFound
+
+        mock_get_transcript.side_effect = NoTranscriptFound("vid", [], {})
+
+        # Simulate the 1.x return: a FetchedTranscript exposing to_raw_data().
+        fetched = Mock()
+        fetched.to_raw_data.return_value = [
+            {"text": "Hello", "start": 0.0},
+            {"text": "world", "start": 1.0},
+        ]
+        mock_transcript = Mock()
+        mock_transcript.fetch.return_value = fetched
+        mock_list_result = Mock()
+        mock_list_result.find_transcript.return_value = mock_transcript
+        mock_list_transcripts.return_value = mock_list_result
+
+        transcript, error = app.get_transcript("vid")
+
+        self.assertEqual(transcript, "Hello world")
+        self.assertIsNone(error)
+
     def test_get_transcript_no_video_id(self):
         """Test get_transcript handles empty video ID"""
         transcript, error = app.get_transcript("")

--- a/youtube_helpers.py
+++ b/youtube_helpers.py
@@ -234,10 +234,14 @@ def get_transcript(video_id):
         return (transcript_text, None) if transcript_text.strip() else (None, "Transcript was found but it is empty.")
     except NoTranscriptFound:
         try:
-            transcript_list = (
+            fetched = (
                 YouTubeTranscriptApi.list_transcripts(video_id, proxies=proxies).find_transcript(["en"]).fetch()
             )
-            transcript_text = " ".join([d["text"] for d in transcript_list])
+            # youtube-transcript-api 1.x returns a FetchedTranscript of snippet
+            # objects; 0.x returned a list of dicts. Normalize both to text.
+            if hasattr(fetched, "to_raw_data"):
+                fetched = fetched.to_raw_data()
+            transcript_text = " ".join([seg["text"] if isinstance(seg, dict) else seg.text for seg in fetched])
             return (
                 (transcript_text, None)
                 if transcript_text.strip()


### PR DESCRIPTION
## Problem
The `NoTranscriptFound` fallback in `get_transcript` did:

```python
transcript_list = YouTubeTranscriptApi.list_transcripts(video_id, ...).find_transcript(["en"]).fetch()
transcript_text = " ".join([d["text"] for d in transcript_list])
```

With the installed `youtube-transcript-api` 1.1.0, `fetch()` returns a `FetchedTranscript` of `FetchedTranscriptSnippet` **objects**, not dicts. `d["text"]` raises `TypeError`, which the bare `except Exception` turns into "An unexpected error occurred while fetching the fallback transcript" — so the fallback silently never works. (The primary path only works because the deprecated `get_transcript` classmethod internally converts to raw dicts.)

## Fix
Normalize the fetched result: call `to_raw_data()` when available (1.x) and otherwise read `.text` / `dict["text"]`, so both 0.x and 1.x shapes work.

## Tests
- Added `test_get_transcript_fallback_v1_fetchedtranscript` (simulates the 1.x `to_raw_data()` shape); the existing 0.x dict-based fallback test still passes. `test_transcript_and_summary.py` → 26 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)