### PR TITLE
Fix: add /health endpoint (container health checks were 404ing)

### DIFF
--- a/app.py
+++ b/app.py
@@ -458,6 +458,28 @@ init_worker_system()
 # --- API ENDPOINTS ---
 
 
+@app.route("/health")
+@app.route("/sse/health")
+def health_check():
+    """Lightweight, unauthenticated health endpoint for container/orchestration
+    health checks (referenced by the Docker/compose configs). Reports liveness
+    plus a quick view of the worker subsystem."""
+    worker_running = bool(
+        WORKER_SYSTEM_AVAILABLE and worker_manager is not None and getattr(worker_manager, "is_running", False)
+    )
+    return (
+        jsonify(
+            {
+                "status": "ok",
+                "worker_system_available": WORKER_SYSTEM_AVAILABLE,
+                "worker_running": worker_running,
+                "sse_connections": len(sse_connections),
+            }
+        ),
+        200,
+    )
+
+
 @app.route("/")
 @require_auth
 def home():

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -35,6 +35,16 @@ class TestYouTubeSummarizer(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
 
     @patch("app.LOGIN_ENABLED", True)
+    def test_health_endpoints_are_public(self):
+        """/health and /sse/health must respond 200 without auth (container health checks)."""
+        if "TESTING" in os.environ:
+            del os.environ["TESTING"]
+        for path in ("/health", "/sse/health"):
+            response = self.client.get(path)
+            self.assertEqual(response.status_code, 200, path)
+            self.assertEqual(response.get_json()["status"], "ok")
+
+    @patch("app.LOGIN_ENABLED", True)
     def test_home_page_requires_auth_when_enabled(self):
         """Test that home page redirects to login when authentication is enabled and user not logged in"""
         # Remove testing environment variable to enable authentication


### PR DESCRIPTION
## Problem
The container health checks probe endpoints that don't exist:

- `Dockerfile.sse` and `docker-compose-podman.yml` → `http://localhost:5001/health`
- `docker-compose-sse.yml` → `http://localhost:5001/sse/health`

Since neither route is defined, every health check returns 404, so containers are marked unhealthy and restart-loop under these configs.

## Fix
Add an unauthenticated `health_check` view served at both `/health` and `/sse/health`. It returns `200` with a small JSON body (liveness + worker-system status + active SSE connection count). It deliberately has no `@require_auth` so probes work regardless of `LOGIN_ENABLED`.

## Tests
- Added `test_health_endpoints_are_public` (asserts 200 + `status: ok` even with `LOGIN_ENABLED=True`). `test_app.py` → 65 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)