### PR TITLE
CI: report all test failures; lint + cover the extracted modules

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,14 +37,19 @@ jobs:
     
     - name: Run linting
       run: |
-        flake8 app.py --max-line-length=120 --exclude=venv,__pycache__
-    
+        flake8 app.py ai_models.py auth.py cache.py tts_helpers.py youtube_helpers.py \
+          worker_manager.py job_queue.py job_models.py job_state.py error_handler.py \
+          sse_manager.py voice_config.py --max-line-length=120 --exclude=venv,__pycache__
+
     - name: Run tests with coverage
       env:
         GOOGLE_API_KEY: test_api_key
         TESTING: true
       run: |
-        pytest --cov=app --cov-report=xml --cov-report=term-missing -v
+        pytest --cov=app --cov=ai_models --cov=auth --cov=cache --cov=tts_helpers \
+          --cov=youtube_helpers --cov=worker_manager --cov=job_queue --cov=job_models \
+          --cov=job_state --cov=error_handler --cov=sse_manager --cov=voice_config \
+          --cov-report=xml --cov-report=term-missing -v
     
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,7 +3,7 @@ testpaths = tests
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
-addopts = -v --tb=short --strict-markers --maxfail=10 -x
+addopts = -v --tb=short --strict-markers --maxfail=10
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
     integration: marks tests as integration tests


### PR DESCRIPTION
## Problem
1. `pytest.ini` had `addopts = ... --maxfail=10 -x`. `-x` (stop on first failure) wins, so CI and local runs stop at the **first** failing test and hide everything after it; `--maxfail=10` was dead config.
2. CI only linted `app.py` and measured coverage with `--cov=app`. The modules extracted from `app.py` in the recent refactor (`ai_models`, `auth`, `cache`, `tts_helpers`, `youtube_helpers`, `worker_manager`, `job_queue`, `job_models`, `job_state`, `error_handler`, `sse_manager`, `voice_config`) were never linted or coverage-measured in CI.

## Fix
- Drop `-x` from `pytest.ini` so up to 10 failures are reported per run.
- Add the extracted modules to the CI `flake8` command (all are currently flake8-clean) and to the `pytest --cov=...` flags.

## Verification
- YAML parses; `pytest ... --cov=cache --cov=app` reports `cache.py 100%` and passes.
- Full suite still passes (497 passed, 26 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)