### PR TITLE
Chore: gitignore generated build/test artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 __pycache__/
 *.py[cod]
 *$py.class
+*.egg-info/
+*.egg
 
 # Virtual Environment
 venv/
@@ -65,4 +67,6 @@ htmlcov/
 *.coverage
 coverage.xml
 .tox/
-test-reports/ 
+test-reports/
+tests/test_cache.json
+tests/test_cache.json.lock 


### PR DESCRIPTION
## Problem
The working tree accumulates generated files that aren't ignored, so they keep showing up in `git status` and risk being committed:

- `youtube_summarizer.egg-info/` — editable-install metadata (and the project no longer has a `setup.py`/`pyproject.toml`, so it's stale).
- `tests/test_cache.json` and `tests/test_cache.json.lock` — runtime artifacts created by a test helper.

## Fix
Add `*.egg-info/`, `*.egg`, and the two `tests/test_cache.json*` paths to `.gitignore`. (`data/`, `audio_cache/`, `summary_cache.json`, and `.env` were already ignored.)

## Note for the reviewer
Two other untracked files were flagged by the audit but are **not** touched here because they're hand-written source, not generated artifacts — your call whether to keep them:
- `utils.py` — an abandoned `CacheManager` (fcntl-locked) that nothing imports. The atomic-write fix it was meant for is implemented directly in `cache.py` in a separate PR, so this file is now redundant.
- `tests/verify_cache_fix.py` — a manual verification script (not collected by pytest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)